### PR TITLE
fix(ci): specify artifact id when deploying to GH pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,7 @@ jobs:
         run: yarn build
 
       - name: Upload Build Artifact
+        id: deployment
         uses: actions/upload-pages-artifact@v3
         with:
           path: build


### PR DESCRIPTION
The `Deploy to GitHub Pages` step using the `actions/deploy-pages@v4` action was not able to find an artifact with ID `deployment`, so it was pushing empty content to the GH pages deployment environment.
